### PR TITLE
Keep all qualifiers when converting from Coral to Biopython features

### DIFF
--- a/coral/seqio/_dna.py
+++ b/coral/seqio/_dna.py
@@ -295,7 +295,9 @@ def _coral_to_seqfeature(feature):
         location = FeatureLocation(ExactPosition(feature.start),
                                    ExactPosition(feature.stop),
                                    strand=bio_strand)
+    qualifiers = feature.qualifiers
+    qualifiers['label'] = [feature.name]
     seqfeature = SeqFeature(location, type=ftype,
-                            qualifiers={'label': [feature.name]},
+                            qualifiers=qualifiers,
                             location_operator=location_operator)
     return seqfeature


### PR DESCRIPTION
This prevents ApE annotation colors from being lost
